### PR TITLE
Feat: Display playback speed in transcript

### DIFF
--- a/src/app/video/[jobId]/page.tsx
+++ b/src/app/video/[jobId]/page.tsx
@@ -954,6 +954,9 @@ export default function VideoJobPage() {
                     <span className="text-xs font-mono text-blue-400 mr-2">
                       {formatTimestamp(segment.start ?? 0)}
                     </span>
+                    {segment.playback_speed && segment.playback_speed !== 1 && (
+                      <span className="text-xs text-teal-400 mr-2">{segment.playback_speed}x</span>
+                    )}
                     <span className={`text-sm ${segment.can_skip ? 'text-gray-500 line-through' : 'text-gray-200'}`}>
                       {segment.text}
                     </span>


### PR DESCRIPTION
I modified the transcript view on the video page to display the playback speed (e.g., "1.5x", "2x") for each segment if its speed is not 1x.

This information is added subtly next to the segment's timestamp, maintaining the clean look of the transcript and ensuring it doesn't interfere with existing styling for skippable segments.