### PR TITLE
Fix backend URL fallbacks

### DIFF
--- a/src/app/api/process-status/route.ts
+++ b/src/app/api/process-status/route.ts
@@ -1,6 +1,8 @@
 // filepath: src/app/api/process-status/route.ts
 import { NextResponse, NextRequest } from 'next/server';
 
+const PI_SERVER = process.env.PI_SERVER || 'http://100.70.34.122:3001'
+
 export async function GET(req: NextRequest) {
   try {
     const { searchParams } = new URL(req.url);
@@ -10,7 +12,7 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ error: 'jobId query parameter is required' }, { status: 400 });
     }
 
-    const backendUrl = `${process.env.PI_SERVER}/process/status/${jobId}`; // Your backend status endpoint
+    const backendUrl = `${PI_SERVER}/process/status/${jobId}`; // Your backend status endpoint
     console.log(`Polling backend status: ${backendUrl}`);
 
     const backendResponse = await fetch(backendUrl, {

--- a/src/app/api/process-video/route.ts
+++ b/src/app/api/process-video/route.ts
@@ -12,7 +12,7 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: 'fileKey is required' }, { status: 400 });
     }
 
-    const backendUrl = `${process.env.PI_SERVER}/process/s3-video`; // Your backend endpoint
+    const backendUrl = `${PI_SERVER}/process/s3-video`; // Your backend endpoint
     console.log(`Forwarding process request to backend: ${backendUrl} for key: ${fileKey}`);
 
     const backendResponse = await fetch(backendUrl, {

--- a/src/app/api/process-youtube/route.ts
+++ b/src/app/api/process-youtube/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from 'next/server';
 
+const PI_SERVER = process.env.PI_SERVER || 'http://100.70.34.122:3001'
+
 export async function POST(req: Request) {
   try {
     const body = await req.json();
@@ -14,7 +16,7 @@ export async function POST(req: Request) {
        return NextResponse.json({ error: 'Invalid YouTube URL format' }, { status: 400 });
     }
 
-    const backendUrl = `${process.env.PI_SERVER}/process/youtube-url`; // Your NEW backend endpoint
+    const backendUrl = `${PI_SERVER}/process/youtube-url`; // Your NEW backend endpoint
     console.log(`Forwarding YouTube URL request to backend: ${backendUrl}`);
 
     const backendResponse = await fetch(backendUrl, {


### PR DESCRIPTION
## Summary
- use `PI_SERVER` fallback in `process-video` route
- use `PI_SERVER` fallback in `process-status` route
- use `PI_SERVER` fallback in `process-youtube` route

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-unused-vars, etc.)*
- `npm run build` *(fails to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68419b10ba84832389037f71e2da3f8e